### PR TITLE
Silence constexpr-related build warnings

### DIFF
--- a/sgcl/detail/child_pointers.h
+++ b/sgcl/detail/child_pointers.h
@@ -17,7 +17,7 @@ namespace sgcl::detail {
         using Map = std::vector<std::atomic<uint8_t>>;
         using Vector = std::vector<ptrdiff_t>;
 
-        constexpr ChildPointers(bool f, size_t object_size) noexcept
+        ChildPointers(bool f, size_t object_size) noexcept
         : final(f)
         , map(f ? 0 : (object_size + sizeof(RawPointer) * 8 - 1) / (sizeof(RawPointer) * 8)) {
         };

--- a/sgcl/detail/thread.h
+++ b/sgcl/detail/thread.h
@@ -44,7 +44,7 @@ namespace sgcl::detail {
             ChildGuard(const ChildGuard&) = delete;
             void operator=(const ChildGuard&) = delete;
 
-            constexpr ChildGuard(Thread& t, ChildPointers cp) noexcept
+            ChildGuard(Thread& t, ChildPointers cp) noexcept
             : thread(t)
             , old_pointers(t.child_pointers) {
                 thread.child_pointers = cp;
@@ -62,7 +62,7 @@ namespace sgcl::detail {
             RangeGuard(const RangeGuard&) = delete;
             void operator=(const RangeGuard&) = delete;
 
-            constexpr RangeGuard(Thread& t, std::pair<uintptr_t, uintptr_t> ar) noexcept
+            RangeGuard(Thread& t, std::pair<uintptr_t, uintptr_t> ar) noexcept
             : thread(t)
             , old_alloc_range(t.alloc_range) {
                 thread.alloc_range = ar;


### PR DESCRIPTION
## Summary
- drop `constexpr` from `ChildPointers` ctor
- drop `constexpr` from thread guard ctors

## Testing
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_689b56542a8c832f9734b24c17456b41